### PR TITLE
Add-LinkClick-Event-DLMapping

### DIFF
--- a/models/tealium-event.js
+++ b/models/tealium-event.js
@@ -86,6 +86,11 @@ const DataLayerMapping = {
   placement_updated_dt: 'placement_updated_dt',
   user_id: 'user_id',
   taxonomy: 'taxonomy',
+  target_url: 'target_url',
+  element_id: 'element_id',
+  element_classes: 'element_classes',
+  element_target: 'element_target',
+  element_content: 'element_content',
   collector_tstamp: ['tealium_timestamp_utc', 'tealium_timestamp_epoch']
 }
 const HeaderMapping = {


### PR DESCRIPTION
This pr adds the necessary key values pairs to our data layer mapping object for link click events from snowplow to feed into Tealium. The key is the variable name coming from the derived table and the value is the variable we are mapping it to inside of Tealium.