### PR TITLE
update-taxonomy-context-capture

### DIFF
--- a/models/tealium-event.js
+++ b/models/tealium-event.js
@@ -161,12 +161,10 @@ class TealiumEvent {
         }
       })
     }
-    if(typeof this.event.data[TealiumEvent.TAXONOMY_CONTEXT] !== 'undefined') {
-      console.log(this.event.data[TealiumEvent.TAXONOMY_CONTEXT])
-    }
+
     if (isArray(this.event.data[TealiumEvent.TAXONOMY_CONTEXT])) {
       const taxonomy = this.event.data[TealiumEvent.TAXONOMY_CONTEXT][0]
-      identityParams.taxonomy = this.fieldValue(taxonomy.taxonomy, 'taxonomy')
+      identityParams.taxonomy = taxonomy.taxonomy.toString()
     }
 
     // Set tealium_visitor_id to the domain_userid or device_idfa, whichever is first present.


### PR DESCRIPTION
I'm thinking the taxonomy is not being sent because we are trying to send an array. Nowhere else do we send an array and anywhere that the data is an array we convert it to a string. Hopefully, this will fix the issue.