### PR TITLE
Cleanup-Taxonomy-Context

### DIFF
--- a/models/tealium-event.js
+++ b/models/tealium-event.js
@@ -85,7 +85,6 @@ const DataLayerMapping = {
   placement: 'sob_placement',
   placement_updated_at: 'placement_updated_at',
   network_userid: 'snowplow_thirdparty_id',
-  taxonomy: 'taxonomy',
   target_url: 'target_url',
   element_id: 'element_id',
   element_classes: 'element_classes',


### PR DESCRIPTION
The last fix didn't work, but looking at how the dataLayer function works, I think this will fix it. I think ```this.identityParameters.taxonomy``` has the value I'm looking for, but then that value is overridden with a null or undefined value by this: https://github.com/CruGlobal/cru-udp-pipeline/blob/eec50793c77934370b09b9f9e5f45e2a6713e6c9/models/tealium-event.js#L120 
I think it was mapping through and overwrote taxonomy, which would have an undefined value in ```this.event.data["taxonomy"]```, and it is then removed by the ```omitBy``` which has ```isNil``` as a second parameter.