### PR TITLE
remove network_userid mapping

### DIFF
--- a/models/tealium-event.js
+++ b/models/tealium-event.js
@@ -84,7 +84,6 @@ const DataLayerMapping = {
   domain_sessionid: 'tealium_session_id',
   placement: 'sob_placement',
   placement_updated_at: 'placement_updated_at',
-  network_userid: 'snowplow_thirdparty_id',
   snowplow_thirdparty_id: 'snowplow_thirdparty_id',
   target_url: 'target_url',
   element_id: 'element_id',


### PR DESCRIPTION
Ran into the same situation again where the value was being mapped over to a null value and removed. So I moved from sending in the pipeline to adding enrichment for the ```snowplow_thirdparty_id``` event attribute on the Tealium side. We capture the ```network_userid``` as ```tealium_thirdparty_visitor_id``` in Tealium. 