### PR TITLE
Add-Empty-Array-Check-For-Link-Click-Events

### DIFF
--- a/models/tealium-event.js
+++ b/models/tealium-event.js
@@ -167,7 +167,7 @@ class TealiumEvent {
     if (isObject(this.event.data[TealiumEvent.LINK_CLICK_CONTEXT])) {
       forEach(['targetUrl', 'elementId', 'elementClasses', 'elementTarget', 'elementContent'], field => {
         if (typeof this.event.data[TealiumEvent.LINK_CLICK_CONTEXT][field] !== 'undefined' && this.event.data[TealiumEvent.LINK_CLICK_CONTEXT][field] !== '' && field) {
-          if (field == 'elementClasses') {
+          if (field == 'elementClasses' && this.event.data[TealiumEvent.LINK_CLICK_CONTEXT].elementClasses.length > 0) {
             identityParams.elementClasses = this.event.data[TealiumEvent.LINK_CLICK_CONTEXT].elementClasses.toString()
           } else {
             identityParams[field] = this.event.data[TealiumEvent.LINK_CLICK_CONTEXT][field]


### PR DESCRIPTION
I forgot to add a check for empty arrays as well. This should hopefully be the last change related to link click events.