### PR TITLE
Fix-Capturing-ACS-Context

### DIFF
--- a/models/tealium-event.js
+++ b/models/tealium-event.js
@@ -179,9 +179,10 @@ class TealiumEvent {
     }
 
     if (isArray(this.event.data[TealiumEvent.ACS_CONTEXT])) {
+      const acsValues = this.event.data[TealiumEvent.ACS_CONTEXT][0]
       forEach(['acs_label', 'acs_click_url'], field => {
-        if (typeof this.event.data[TealiumEvent.ACS_CONTEXT][field] !== 'undefined' && field) {
-          identityParams[field] = this.event.data[TealiumEvent.ACS_CONTEXT][field]
+        if (typeof acsValues[field] !== 'undefined' && acsValues[field]) {
+          identityParams[field] = acsValues[field]
         }
       })
     }


### PR DESCRIPTION
The context comes in as an array and I forgot to grab the first index of that array 🤦‍♂️ I changed it to be similar to how we capture the ids context: 
https://github.com/CruGlobal/cru-udp-pipeline/blob/9f0eec4ef38710c53a03afaf9119a0e14aabfeed/models/tealium-event.js#L155-L162

I also confirmed by querying big query that the values are coming in so with this fix it should get to Tealium:
<img width="1124" alt="Screen Shot 2021-02-05 at 9 32 58 AM" src="https://user-images.githubusercontent.com/39680460/107048989-93a94a00-6797-11eb-8d7c-7dbabc3b039a.png">
